### PR TITLE
Check for already defined constants

### DIFF
--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -19,9 +19,9 @@ final class ServiceMap
             throw new \InvalidArgumentException(sprintf('Provided config path %s must exist', $configPath));
         }
 
-        \define('YII_ENV_DEV', false);
-        \define('YII_ENV_PROD', false);
-        \define('YII_ENV_TEST', true);
+        \defined('YII_ENV_DEV') or \define('YII_ENV_DEV', false);
+        \defined('YII_ENV_PROD') or \define('YII_ENV_PROD', false);
+        \defined('YII_ENV_TEST') or \define('YII_ENV_TEST', true);
 
         $config = require $configPath;
         foreach ($config['container']['singletons'] as $id => $service) {


### PR DESCRIPTION
In case those constants are already defined in the autoloading/bootstrap file, we might want to check if they already exist to avoid throwing a NOTICE