### PR TITLE
Handle return-type of HeaderCollection->get()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -21,6 +21,9 @@ services:
         class: Proget\PHPStan\Yii2\Type\ActiveRecordDynamicMethodReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
     -
+        class: Proget\PHPStan\Yii2\Type\HeaderCollectionDynamicMethodReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
         class: Proget\PHPStan\Yii2\Type\ActiveRecordDynamicStaticMethodReturnTypeExtension
         tags: [phpstan.broker.dynamicStaticMethodReturnTypeExtension]
     -

--- a/src/Type/HeaderCollectionDynamicMethodReturnTypeExtension.php
+++ b/src/Type/HeaderCollectionDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Proget\PHPStan\Yii2\Type;
+
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use yii\web\HeaderCollection;
+
+class HeaderCollectionDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return HeaderCollection::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'get';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        if (count($methodCall->args) < 3) {
+            // $first === true (the default) and the get-method returns something of type string
+            return new StringType();
+        }
+
+        $val = $methodCall->args[2]->value;
+        if ($val instanceof ConstFetch) {
+            $value = $val->name->parts[0];
+            if ($value === 'true') {
+                // $first === true, therefore string
+                return new StringType();
+            }
+
+            if ($value === 'false') {
+                // $first === false, therefore string[]
+                return new ArrayType(new IntegerType(), new StringType());
+            }
+        }
+
+        // Unable to figure out value of third parameter $first, therefore it can be of either type
+        return new UnionType([new ArrayType(new IntegerType(), new StringType()), new StringType()]);
+    }
+}

--- a/tests/Yii/MyController.php
+++ b/tests/Yii/MyController.php
@@ -49,5 +49,10 @@ final class MyController extends \yii\web\Controller
         \Yii::createObject(static function (): \SplObjectStorage {
             return new \SplObjectStorage();
         })->count();
+
+        (int)\Yii::$app->request->headers->get('Content-Length');
+        (int)\Yii::$app->request->headers->get('Content-Length', 0, true);
+        $values = \Yii::$app->request->headers->get('X-Key', '', false);
+        reset($values);
     }
 }


### PR DESCRIPTION
The default behavior does not distinguish between `string[]` or `string`; this PR covers some common use-cases. 

Also added three test-cases in the controller, which fail without the new extension, because `phpstan` was unable to detect the return type. 
