### PR TITLE
Fixed notice for undefined-index

### DIFF
--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -74,7 +74,7 @@ final class ServiceMap
     public function getComponentClassById(string $id): ?string
     {
         // Special case in which the component is already initialized
-        if (is_object($this->components[$id])) {
+        if (isset($this->components[$id]) && is_object($this->components[$id])) {
             return get_class($this->components[$id]);
         }
 


### PR DESCRIPTION
Without this bugfix, under PHP 7.3.9 with notices enabled, the following is outputted:

```
$ composer stan

PHP Notice:  Undefined index: request in /home/e.bruines00000/workspaces/phpstan-yii2/src/ServiceMap.php on line 77
PHP Notice:  Undefined index: request in /home/e.bruines00000/workspaces/phpstan-yii2/src/ServiceMap.php on line 77
PHP Notice:  Undefined index: response in /home/e.bruines00000/workspaces/phpstan-yii2/src/ServiceMap.php on line 77
PHP Notice:  Undefined index: response in /home/e.bruines00000/workspaces/phpstan-yii2/src/ServiceMap.php on line 77
PHP Notice:  Undefined index: user in /home/e.bruines00000/workspaces/phpstan-yii2/src/ServiceMap.php on line 77
PHP Notice:  Undefined index: user in /home/e.bruines00000/workspaces/phpstan-yii2/src/ServiceMap.php on line 77
```