### PR TITLE
Add support for non-singlteon services (definitions)

### DIFF
--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -71,10 +71,9 @@ final class ServiceMap
         return $this->components[$id]['class'] ?? null;
     }
 
-
     /**
-     * @param string $id
      * @param string|\Closure|array<mixed> $service
+     *
      * @throws \ReflectionException
      */
     private function addServiceDefinition(string $id, $service): void

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -46,10 +46,6 @@ final class ServiceMap
                 throw new \RuntimeException(sprintf('Invalid value for component with id %s. Expected object or array.', $id));
             }
 
-            if (null !== $identityClass = $component['identityClass'] ?? null) {
-                $this->components[$id]['identityClass'] = $identityClass;
-            }
-
             if (null !== $class = $component['class'] ?? null) {
                 $this->components[$id]['class'] = $class;
             }
@@ -75,10 +71,6 @@ final class ServiceMap
         return $this->components[$id]['class'] ?? null;
     }
 
-    public function getComponentIdentityClassById(string $id): ?string
-    {
-        return $this->components[$id]['identityClass'] ?? null;
-    }
 
     /**
      * @param string $id

--- a/tests/ServiceMapTest.php
+++ b/tests/ServiceMapTest.php
@@ -39,6 +39,10 @@ final class ServiceMapTest extends TestCase
     {
         $serviceMap = new ServiceMap(__DIR__.DIRECTORY_SEPARATOR.'assets'.DIRECTORY_SEPARATOR.'yii-config-valid.php');
 
+        $this->assertSame(\SplStack::class, $serviceMap->getServiceClassFromNode(new String_('singleton-closure')));
+        $this->assertSame(\SplObjectStorage::class, $serviceMap->getServiceClassFromNode(new String_('singleton-service')));
+        $this->assertSame(\SplFileInfo::class, $serviceMap->getServiceClassFromNode(new String_('singleton-nested-service-class')));
+
         $this->assertSame(\SplStack::class, $serviceMap->getServiceClassFromNode(new String_('closure')));
         $this->assertSame(\SplObjectStorage::class, $serviceMap->getServiceClassFromNode(new String_('service')));
         $this->assertSame(\SplFileInfo::class, $serviceMap->getServiceClassFromNode(new String_('nested-service-class')));

--- a/tests/assets/yii-config-valid.php
+++ b/tests/assets/yii-config-valid.php
@@ -11,6 +11,15 @@ return [
     ],
     'container' => [
         'singletons' => [
+            'singleton-closure' => function(): \SplStack {
+                return new \SplStack();
+            },
+            'singleton-service' => ['class' => \SplObjectStorage::class],
+            'singleton-nested-service-class' => [
+                ['class' => \SplFileInfo::class]
+            ]
+        ],
+        'definitions' => [
             'closure' => function(): \SplStack {
                 return new \SplStack();
             },


### PR DESCRIPTION
This adds support for services that are not defined as singletions (using the `definitions` key).
I also took the liberty to remove some unused code. If I was wrong about that, or you would rather have a separate PR for that I can remove it here.