### PR TITLE
Resolve active record static method type by return type

### DIFF
--- a/src/Type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
+++ b/src/Type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
@@ -8,21 +8,40 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
 
 final class ActiveRecordDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
 {
     public function getClass(): string
     {
-        return 'yii\db\ActiveRecord';
+        return ActiveRecord::class;
     }
 
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool
     {
-        return \in_array($methodReflection->getName(), ['findOne', 'find'], true);
+        $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        if ($returnType instanceof ThisType) {
+            return true;
+        }
+
+        if ($returnType instanceof UnionType) {
+            foreach ($returnType->getTypes() as $type) {
+                if ($type instanceof ObjectType) {
+                    return \is_a($type->getClassName(), $this->getClass(), true);
+                }
+            }
+        }
+
+        return $returnType instanceof ObjectType && \is_a($returnType->getClassName(), ActiveQuery::class, true);
     }
 
     public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
@@ -31,8 +50,12 @@ final class ActiveRecordDynamicStaticMethodReturnTypeExtension implements Dynami
         $className = $methodCall->class;
         $name = $scope->resolveName($className);
 
-        $methodName = $methodReflection->getName();
-        if ($methodName === 'findOne') {
+        $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        if ($returnType instanceof ThisType) {
+            return new ActiveRecordObjectType($name);
+        }
+
+        if ($returnType instanceof UnionType) {
             return TypeCombinator::union(
                 new NullType(),
                 new ActiveRecordObjectType($name)

--- a/tests/Yii/MyController.php
+++ b/tests/Yii/MyController.php
@@ -24,6 +24,12 @@ final class MyController extends \yii\web\Controller
             $flag = $record['flag'];
         }
 
+        $record = MyActiveRecord::findBySql('');
+        if ($record = $record->one()) {
+            $flag = $record->flag;
+            $flag = $record['flag'];
+        }
+
         $records = MyActiveRecord::find()->asArray()->where(['flag' => \Yii::$app->request->post('flag', true)])->all();
         foreach ($records as $record) {
             $flag = $record['flag'];


### PR DESCRIPTION
Merge after #39.

An attempt to automagically resolve stan type from method return type. This adds support, for example, for `findBySql` static method.